### PR TITLE
Access `haltBoot` flag through global object

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -40,7 +40,7 @@ function setupMessageListeners(onMessage: typeof chrome.runtime.onMessage ,pageA
   });
 }
 
-if (!haltBoot) {
+if (!window.haltBoot) {
   setupMessageListeners(chrome.runtime.onMessage, chrome.pageAction);
 }
 

--- a/content/index.ts
+++ b/content/index.ts
@@ -48,7 +48,7 @@ async function main(chromeApi: PartialChromeRuntimeApi, api: PartialDocumentApi)
   await alertBackgroundScriptOfReadiness(chromeApi.sendMessage, api);
 }
 
-if (!haltBoot) main(chrome.runtime, document);
+if (!window.haltBoot) main(chrome.runtime, document);
 
 export {
   setupMessageListeners,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ async function main() {
   await bootUI(pageInfo);
   debug('component boot complete');
 }
-if (!haltBoot) {
+if (!window.haltBoot) {
   main();
 }
 


### PR DESCRIPTION
This is to fix a bug where if `haltBoot` is not defined, the extension throws an error﻿
